### PR TITLE
✨[Feat] API 연동을 위한 공통 Network 구조 추가

### DIFF
--- a/WHYLOG/WHYLOG/Network/7.swift
+++ b/WHYLOG/WHYLOG/Network/7.swift
@@ -1,8 +1,0 @@
-//
-//  7.swift
-//  WHYLOG
-//
-//  Created by 김종수 on 12/16/25.
-//
-
-import Foundation

--- a/WHYLOG/WHYLOG/Network/APIEndpoint.swift
+++ b/WHYLOG/WHYLOG/Network/APIEndpoint.swift
@@ -1,0 +1,74 @@
+//
+//  APIEndpoint.swift
+//  WHYLOG
+//
+//  Created by 김진서 on 12/20/25.
+//
+
+enum APIEndpoint {
+
+    // MARK: - Report
+    case createReport(userId: Int)
+    case fetchReports(userId: Int)
+    case updateReport(userId: Int, reportId: Int)
+    case deleteReport(userId: Int, reportId: Int)
+
+    // MARK: - User
+    case createUser
+    case fetchUser(userId: Int)
+    case updateUser(userId: Int)
+    case deleteUser(userId: Int)
+
+    // MARK: - Record
+    case createRecord(userId: Int)
+    case fetchRecords(userId: Int)
+    case updateRecord(userId: Int, recordId: Int)
+    case deleteRecord(userId: Int, recordId: Int)
+}
+
+// path/method
+extension APIEndpoint {
+
+    var path: String {
+        switch self {
+
+        case .createReport(let userId),
+             .fetchReports(let userId):
+            return "/api/users/\(userId)/reports"
+
+        case .updateReport(let userId, let reportId),
+             .deleteReport(let userId, let reportId):
+            return "/api/users/\(userId)/reports/\(reportId)"
+
+        case .createUser:
+            return "/api/user"
+
+        case .fetchUser(let userId),
+             .updateUser(let userId),
+             .deleteUser(let userId):
+            return "/api/user/\(userId)"
+
+        case .createRecord(let userId),
+             .fetchRecords(let userId):
+            return "/api/users/\(userId)/records"
+
+        case .updateRecord(let userId, let recordId),
+             .deleteRecord(let userId, let recordId):
+            return "/api/users/\(userId)/records/\(recordId)"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .fetchReports, .fetchUser, .fetchRecords:
+            return .get
+        case .createReport, .createUser, .createRecord:
+            return .post
+        case .updateReport, .updateUser, .updateRecord:
+            return .put
+        case .deleteReport, .deleteUser, .deleteRecord:
+            return .delete
+        }
+    }
+}
+

--- a/WHYLOG/WHYLOG/Network/HTTPMethod.swift
+++ b/WHYLOG/WHYLOG/Network/HTTPMethod.swift
@@ -1,0 +1,14 @@
+//
+//  HTTPMethod.swift
+//  WHYLOG
+//
+//  Created by 김진서 on 12/20/25.
+//
+
+enum HTTPMethod: String {
+    case get    = "GET"
+    case post   = "POST"
+    case put    = "PUT"
+    case patch  = "PATCH"
+    case delete = "DELETE"
+}

--- a/WHYLOG/WHYLOG/Network/NetworkClient.swift
+++ b/WHYLOG/WHYLOG/Network/NetworkClient.swift
@@ -1,0 +1,37 @@
+//
+//  NetworkClient.swift
+//  WHYLOG
+//
+//  Created by 김진서 on 12/20/25.
+//
+
+import Foundation
+
+struct NetworkClient {
+
+    static let baseURL = "https://YOUR_SERVER_URL"
+
+    static func request<T: Decodable>(
+        endpoint: APIEndpoint,
+        body: Data? = nil
+    ) async throws -> T {
+
+        let url = URL(string: baseURL + endpoint.path)!
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+


### PR DESCRIPTION
### 📌 작업 내용
- API 연동을 위한 공통 Network 레이어 추가
- Endpoint / HTTP Method 분리
- URLSession 기반 공통 요청 구조 구현

### 📂 추가된 파일
- Network/APIEndpoint.swift
- Network/HTTPMethod.swift
- Network/NetworkClient.swift

### 📝 비고
- 리포트 API 기준으로 먼저 구조 정리
- 이후 User / Record API 동일 구조로 확장 가능
